### PR TITLE
Add lighting effects and trigger hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,8 @@ Several modules are provided which you can extend:
 
 * `src/rest_api.py` – FastAPI-based REST API server and web panel.
 * `src/mqtt.py` – add MQTT handling if required.
-* `src/effects.py` – build a light effect engine.
+* `src/effects.py` – light effect engine with basic animations.
+* `src/favorites.py` – store favourite colors for reuse.
 
 Networking helpers for Art-Net are in `src/network.py` and LED device
 definitions in `src/devices.py`.
@@ -89,5 +90,11 @@ is available at `/panel` and the following API endpoints are exposed:
 * `POST /groups` – create a new group.
 * `POST /devices/{name}/command` – send a hex encoded DMX payload to a device.
 * `POST /groups/{name}/command` – send a command to all devices in a group.
+* `POST /devices/{name}/effect` – run a built-in light effect on a device.
+* `POST /groups/{name}/effect` – run an effect on all devices in a group.
+* `GET /favorites` – list stored colours.
+* `POST /favorites` – add a favourite colour.
+* `DELETE /favorites/{name}` – remove a favourite colour.
+* `POST /triggers/{event}` – trigger a named event hook.
 
 Use any HTTP client or the web panel to manage your lighting setup.

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 PyYAML>=6.0
 fastapi>=0.100
 uvicorn>=0.22
+paho-mqtt>=1.6
 
 pytest>=7.0

--- a/src/effects.py
+++ b/src/effects.py
@@ -1,11 +1,74 @@
-"""Placeholder light effect engine."""
+"""Light effect generation utilities."""
+
 from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import List, Tuple
+import math
+import random
+
+
+@dataclass
+class Color:
+    """Simple RGB color container."""
+
+    r: int
+    g: int
+    b: int
+
+    def clamp(self) -> None:
+        self.r = max(0, min(255, int(self.r)))
+        self.g = max(0, min(255, int(self.g)))
+        self.b = max(0, min(255, int(self.b)))
+
+    def as_bytes(self) -> bytes:
+        self.clamp()
+        return bytes((self.r, self.g, self.b))
 
 
 class EffectEngine:
-    """Simple effect engine placeholder."""
+    """Generate pixel frames for various lighting effects."""
 
-    def run(self) -> None:
-        """Run light effects."""
-        # TODO: Implement effect generation logic
-        raise NotImplementedError("Effect engine not implemented yet")
+    def __init__(self, pixel_count: int) -> None:
+        self.pixel_count = pixel_count
+
+    def _repeat(self, color: Color) -> List[Color]:
+        return [Color(color.r, color.g, color.b) for _ in range(self.pixel_count)]
+
+    def color_cycle(self, colors: List[Color], step: int) -> List[Color]:
+        """Return a frame cycling through the given colors."""
+        if not colors:
+            return self._repeat(Color(0, 0, 0))
+        index = step % len(colors)
+        return self._repeat(colors[index])
+
+    def flicker(
+        self, color: Color, intensity: Tuple[float, float], step: int
+    ) -> List[Color]:
+        """Return a flickering frame using random brightness variation."""
+        low, high = intensity
+        scale = random.uniform(low, high)
+        flick = Color(int(color.r * scale), int(color.g * scale), int(color.b * scale))
+        flick.clamp()
+        return self._repeat(flick)
+
+    def wave(self, color: Color, wavelength: int, step: int) -> List[Color]:
+        """Return a wave pattern moving across the pixels."""
+        frame: List[Color] = []
+        for i in range(self.pixel_count):
+            phase = (i + step) / max(1, wavelength)
+            factor = (math.sin(phase * math.tau) + 1) / 2
+            wave_color = Color(
+                int(color.r * factor), int(color.g * factor), int(color.b * factor)
+            )
+            wave_color.clamp()
+            frame.append(wave_color)
+        return frame
+
+    @staticmethod
+    def to_bytes(frame: List[Color]) -> bytes:
+        """Convert a frame to DMX byte payload."""
+        payload = bytearray()
+        for c in frame:
+            payload.extend(c.as_bytes())
+        return bytes(payload)

--- a/src/favorites.py
+++ b/src/favorites.py
@@ -1,0 +1,57 @@
+"""Favorite color storage utilities."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, asdict
+from pathlib import Path
+from typing import Dict, List
+import json
+
+
+@dataclass
+class ColorFavorite:
+    """Named RGB color favorite."""
+
+    name: str
+    r: int
+    g: int
+    b: int
+
+    def as_tuple(self) -> tuple[int, int, int]:
+        return self.r, self.g, self.b
+
+
+class FavoritesManager:
+    """Manage persistence of color favorites in a JSON file."""
+
+    def __init__(self, path: str | Path = "favorites.json") -> None:
+        self.path = Path(path)
+        self._load()
+
+    def _load(self) -> None:
+        if self.path.exists():
+            data = json.loads(self.path.read_text())
+            self.favorites: Dict[str, ColorFavorite] = {
+                item["name"]: ColorFavorite(**item) for item in data
+            }
+        else:
+            self.favorites = {}
+
+    def _save(self) -> None:
+        data = [asdict(fav) for fav in self.favorites.values()]
+        self.path.write_text(json.dumps(data))
+
+    def add(self, name: str, r: int, g: int, b: int) -> None:
+        self.favorites[name] = ColorFavorite(name, r, g, b)
+        self._save()
+
+    def remove(self, name: str) -> None:
+        if name in self.favorites:
+            del self.favorites[name]
+            self._save()
+
+    def list(self) -> List[ColorFavorite]:
+        return list(self.favorites.values())
+
+    def get(self, name: str) -> ColorFavorite | None:
+        return self.favorites.get(name)

--- a/src/mqtt.py
+++ b/src/mqtt.py
@@ -1,11 +1,39 @@
-"""Placeholder MQTT handling."""
+"""MQTT client wrapper used for external triggers."""
+
 from __future__ import annotations
+
+from typing import Callable
+import paho.mqtt.client as mqtt
 
 
 class MQTTClient:
-    """MQTT client placeholder."""
+    """Small helper around paho-mqtt for subscribing to events."""
+
+    def __init__(self) -> None:
+        self.client = mqtt.Client()
 
     def connect(self, broker: str) -> None:
         """Connect to the given MQTT broker."""
-        # TODO: Implement connection logic with paho-mqtt or similar
-        raise NotImplementedError("MQTT client not implemented yet")
+        self.client.connect(broker)
+
+    def subscribe(self, topic: str, callback: Callable[[str], None]) -> None:
+        """Subscribe to a topic and register a callback for messages."""
+
+        def _on_message(
+            _client: mqtt.Client, _userdata: object, msg: mqtt.MQTTMessage
+        ) -> None:
+            callback(msg.payload.decode())
+
+        self.client.subscribe(topic)
+        self.client.message_callback_add(topic, _on_message)
+
+    def start(self) -> None:
+        """Start background network loop."""
+        self.client.loop_start()
+
+    def stop(self) -> None:
+        """Stop background network loop."""
+        self.client.loop_stop()
+
+    def publish(self, topic: str, payload: str) -> None:
+        self.client.publish(topic, payload)

--- a/src/rest_api.py
+++ b/src/rest_api.py
@@ -1,14 +1,17 @@
 """REST API using FastAPI for device control."""
+
 from __future__ import annotations
 
 from dataclasses import asdict
-from typing import Dict, List, Optional
+from typing import Callable, Dict, List, Optional
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import HTMLResponse, PlainTextResponse
 from pydantic import BaseModel
 
 from .devices import LEDDevice
+from .effects import Color, EffectEngine
+from .favorites import FavoritesManager
 from .network import ArtNetClient
 
 
@@ -35,6 +38,15 @@ class LightCommand(BaseModel):
     data: str  # hex encoded bytes
 
 
+class FavoriteModel(BaseModel):
+    """Model describing a color favorite."""
+
+    name: str
+    r: int
+    g: int
+    b: int
+
+
 class RestAPI:
     """Simple REST API server providing device management."""
 
@@ -42,7 +54,30 @@ class RestAPI:
         self.app = FastAPI(title="Piccolo Control Panel")
         self.devices: Dict[str, LEDDevice] = {}
         self.groups: Dict[str, List[str]] = {}
+        self.favorites = FavoritesManager()
+        self.event_hooks: Dict[str, Callable[[dict | None], None]] = {}
+        self.effect_engines: Dict[str, EffectEngine] = {}
         self._setup_routes()
+
+    def add_event_hook(self, name: str, handler: Callable[[dict | None], None]) -> None:
+        """Register a handler to be invoked when an event is triggered."""
+        self.event_hooks[name] = handler
+
+    def _get_engine(self, name: str) -> EffectEngine:
+        if name not in self.effect_engines:
+            pixel_count = self.devices[name].pixel_count
+            self.effect_engines[name] = EffectEngine(pixel_count)
+        return self.effect_engines[name]
+
+    def attach_mqtt(self, topic: str, mqtt_client: "MQTTClient", event: str) -> None:
+        """Bind an MQTT topic to a named event."""
+
+        def _callback(message: str) -> None:
+            handler = self.event_hooks.get(event)
+            if handler:
+                handler({"message": message})
+
+        mqtt_client.subscribe(topic, _callback)
 
     def _setup_routes(self) -> None:
         @self.app.get("/", response_class=PlainTextResponse)
@@ -81,11 +116,27 @@ class RestAPI:
                 raise HTTPException(status_code=400, detail="Group already exists")
             for dev_name in group.devices:
                 if dev_name not in self.devices:
-                    raise HTTPException(status_code=404, detail=f"Device {dev_name} not found")
+                    raise HTTPException(
+                        status_code=404, detail=f"Device {dev_name} not found"
+                    )
             self.groups[group.name] = list(group.devices)
             for dev_name in group.devices:
                 self.devices[dev_name].group = group.name
             return {"status": "group created"}
+
+        @self.app.get("/favorites")
+        def list_favorites() -> List[Dict[str, int]]:
+            return [asdict(f) for f in self.favorites.list()]
+
+        @self.app.post("/favorites")
+        def add_favorite(fav: FavoriteModel) -> Dict[str, str]:
+            self.favorites.add(fav.name, fav.r, fav.g, fav.b)
+            return {"status": "added"}
+
+        @self.app.delete("/favorites/{name}")
+        def delete_favorite(name: str) -> Dict[str, str]:
+            self.favorites.remove(name)
+            return {"status": "removed"}
 
         @self.app.post("/devices/{name}/command")
         def send_command(name: str, cmd: LightCommand) -> Dict[str, str]:
@@ -105,6 +156,58 @@ class RestAPI:
                 client = ArtNetClient(self.devices[dev_name].ip)
                 client.send_dmx(cmd.universe, payload)
             return {"status": "sent"}
+
+        @self.app.post("/groups/{name}/effect")
+        def run_group_effect(name: str, effect: str, step: int = 0) -> Dict[str, str]:
+            if name not in self.groups:
+                raise HTTPException(status_code=404, detail="Group not found")
+            for dev_name in self.groups[name]:
+                engine = self._get_engine(dev_name)
+                if effect == "cycle":
+                    colors = [Color(255, 0, 0), Color(0, 255, 0), Color(0, 0, 255)]
+                    frame = engine.color_cycle(colors, step)
+                elif effect == "wave":
+                    frame = engine.wave(Color(255, 255, 255), 20, step)
+                elif effect == "flicker":
+                    frame = engine.flicker(Color(255, 255, 255), (0.2, 1.0), step)
+                else:
+                    raise HTTPException(status_code=400, detail="Unknown effect")
+                payload = EffectEngine.to_bytes(frame)
+                ArtNetClient(self.devices[dev_name].ip).send_dmx(0, payload)
+            return {"status": "sent"}
+
+        @self.app.post("/devices/{name}/effect")
+        def run_device_effect(name: str, effect: str, step: int = 0) -> Dict[str, str]:
+            if name not in self.devices:
+                raise HTTPException(status_code=404, detail="Device not found")
+            engine = self._get_engine(name)
+            if effect == "cycle":
+                colors = [
+                    Color(r, g, b)
+                    for r, g, b in [
+                        (255, 0, 0),
+                        (0, 255, 0),
+                        (0, 0, 255),
+                    ]
+                ]
+                frame = engine.color_cycle(colors, step)
+            elif effect == "wave":
+                frame = engine.wave(Color(255, 255, 255), 20, step)
+            elif effect == "flicker":
+                frame = engine.flicker(Color(255, 255, 255), (0.2, 1.0), step)
+            else:
+                raise HTTPException(status_code=400, detail="Unknown effect")
+            payload = EffectEngine.to_bytes(frame)
+            ArtNetClient(self.devices[name].ip).send_dmx(0, payload)
+            return {"status": "sent"}
+
+        @self.app.post("/triggers/{event}")
+        def trigger_event(event: str, payload: Optional[dict] = None) -> Dict[str, str]:
+            handler = self.event_hooks.get(event)
+            if not handler:
+                raise HTTPException(status_code=404, detail="Event not registered")
+            handler(payload)
+            return {"status": "triggered"}
 
     def start(self, host: str = "0.0.0.0", port: int = 8000) -> None:
         """Start the REST API server using uvicorn."""

--- a/tests/test_effects.py
+++ b/tests/test_effects.py
@@ -1,0 +1,16 @@
+from src.effects import EffectEngine, Color
+
+
+def test_color_cycle():
+    eng = EffectEngine(3)
+    colors = [Color(1, 2, 3), Color(4, 5, 6)]
+    frame = eng.color_cycle(colors, step=1)
+    assert len(frame) == 3
+    assert frame[0].r == 4
+    assert frame[1].g == 5
+
+
+def test_to_bytes():
+    frame = [Color(1, 2, 3), Color(4, 5, 6)]
+    data = EffectEngine.to_bytes(frame)
+    assert data == b"\x01\x02\x03\x04\x05\x06"

--- a/tests/test_favorites.py
+++ b/tests/test_favorites.py
@@ -1,0 +1,12 @@
+from src.favorites import FavoritesManager
+
+
+def test_add_and_remove(tmp_path):
+    path = tmp_path / "favorites.json"
+    mgr = FavoritesManager(path)
+    mgr.add("red", 255, 0, 0)
+    assert len(mgr.list()) == 1
+    fav = mgr.get("red")
+    assert fav and fav.r == 255 and fav.g == 0 and fav.b == 0
+    mgr.remove("red")
+    assert mgr.get("red") is None


### PR DESCRIPTION
## Summary
- implement animations in `effects` module
- add persistent favorite colour manager
- expose favourite/effect/trigger endpoints in REST API
- provide simple MQTT client
- test new utilities

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e83b6d2e88332ad845144152c5bf1