### PR TITLE
Fix unused import in network module

### DIFF
--- a/src/network.py
+++ b/src/network.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 
 import socket
 from dataclasses import dataclass
-from typing import Tuple
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- remove Tuple import from `src/network.py`

## Testing
- `pyflakes src/network.py`

------
https://chatgpt.com/codex/tasks/task_e_687e8df6a5a8833289edca060555b898