### PR TITLE
Add config loading and CLI entrypoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ The project includes a small FastAPI application exposing REST endpoints
 for device and group management. Launch the server with:
 
 ```bash
-python -m src.rest_api
+python -m piccolo --config config.yaml
 ```
 
 By default it will listen on <http://localhost:8000>. A simple HTML panel

--- a/piccolo/__main__.py
+++ b/piccolo/__main__.py
@@ -1,0 +1,19 @@
+import argparse
+from pathlib import Path
+
+from src.rest_api import RestAPI
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Piccolo REST API server")
+    parser.add_argument("--config", type=Path, help="Path to YAML configuration", required=False)
+    parser.add_argument("--host", default="0.0.0.0", help="Bind host")
+    parser.add_argument("--port", type=int, default=8000, help="Bind port")
+    args = parser.parse_args()
+
+    api = RestAPI(config=args.config) if args.config else RestAPI()
+    api.start(host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/rest_api.py
+++ b/src/rest_api.py
@@ -3,12 +3,14 @@
 from __future__ import annotations
 
 from dataclasses import asdict
+from pathlib import Path
 from typing import Callable, Dict, List, Optional
 
 from fastapi import FastAPI, HTTPException
 from fastapi.responses import HTMLResponse, PlainTextResponse
 from pydantic import BaseModel
 
+from .config import Config, load_config
 from .devices import LEDDevice
 from .effects import Color, EffectEngine
 from .favorites import FavoritesManager
@@ -50,14 +52,24 @@ class FavoriteModel(BaseModel):
 class RestAPI:
     """Simple REST API server providing device management."""
 
-    def __init__(self) -> None:
+    def __init__(self, config: Config | str | Path | None = None) -> None:
         self.app = FastAPI(title="Piccolo Control Panel")
         self.devices: Dict[str, LEDDevice] = {}
         self.groups: Dict[str, List[str]] = {}
         self.favorites = FavoritesManager()
         self.event_hooks: Dict[str, Callable[[dict | None], None]] = {}
         self.effect_engines: Dict[str, EffectEngine] = {}
+        if config:
+            self.load_config(config)
         self._setup_routes()
+
+    def load_config(self, config: Config | str | Path) -> None:
+        """Populate devices and groups from a configuration."""
+        cfg = load_config(config) if isinstance(config, (str, Path)) else config
+        for dev in cfg.devices:
+            self.devices[dev.name] = dev
+            if dev.group:
+                self.groups.setdefault(dev.group, []).append(dev.name)
 
     def add_event_hook(self, name: str, handler: Callable[[dict | None], None]) -> None:
         """Register a handler to be invoked when an event is triggered."""

--- a/tests/test_rest_api.py
+++ b/tests/test_rest_api.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+from src.rest_api import RestAPI
+
+
+def test_api_loads_config(tmp_path):
+    example = Path("config.example.yaml")
+    config = tmp_path / "config.yaml"
+    config.write_text(example.read_text())
+
+    api = RestAPI(config=config)
+    assert "strip1" in api.devices
+    assert api.devices["strip1"].ip == "192.168.1.50"
+    assert "stage_left" in api.groups
+    assert "strip1" in api.groups["stage_left"]


### PR DESCRIPTION
## Summary
- extend `RestAPI` to optionally load configuration on init
- implement CLI entrypoint under `piccolo` package
- update README to document new `python -m piccolo` usage
- add tests for API config loading

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e8e391fa48332b68e464bb00d6e29