### PR TITLE
Add universe setting per device

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -6,7 +6,9 @@ devices:
     ip: "192.168.1.50"
     pixel_count: 150
     group: "stage_left"
+    universe: 0
   - name: "strip2"
     ip: "192.168.1.51"
     pixel_count: 150
     group: "stage_right"
+    universe: 1

--- a/src/config.py
+++ b/src/config.py
@@ -28,6 +28,7 @@ def load_config(path: str | Path) -> Config:
             ip=item["ip"],
             pixel_count=item["pixel_count"],
             group=item.get("group"),
+            universe=item.get("universe", 0),
         )
         for i, item in enumerate(data.get("devices", []))
     ]

--- a/src/devices.py
+++ b/src/devices.py
@@ -13,6 +13,7 @@ class LEDDevice:
     ip: str
     pixel_count: int
     group: str | None = None
+    universe: int = 0
 
 
 @dataclass

--- a/src/rest_api.py
+++ b/src/rest_api.py
@@ -22,6 +22,7 @@ class DeviceModel(BaseModel):
     ip: str
     pixel_count: int
     group: Optional[str] = None
+    universe: int = 0
 
 
 class GroupModel(BaseModel):
@@ -144,7 +145,8 @@ class RestAPI:
                 raise HTTPException(status_code=404, detail="Device not found")
             payload = bytes.fromhex(cmd.data)
             client = ArtNetClient(self.devices[name].ip)
-            client.send_dmx(cmd.universe, payload)
+            base = self.devices[name].universe
+            client.send_dmx(base + cmd.universe, payload)
             return {"status": "sent"}
 
         @self.app.post("/groups/{name}/command")
@@ -154,7 +156,8 @@ class RestAPI:
             for dev_name in self.groups[name]:
                 payload = bytes.fromhex(cmd.data)
                 client = ArtNetClient(self.devices[dev_name].ip)
-                client.send_dmx(cmd.universe, payload)
+                base = self.devices[dev_name].universe
+                client.send_dmx(base + cmd.universe, payload)
             return {"status": "sent"}
 
         @self.app.post("/groups/{name}/effect")
@@ -173,7 +176,8 @@ class RestAPI:
                 else:
                     raise HTTPException(status_code=400, detail="Unknown effect")
                 payload = EffectEngine.to_bytes(frame)
-                ArtNetClient(self.devices[dev_name].ip).send_dmx(0, payload)
+                base = self.devices[dev_name].universe
+                ArtNetClient(self.devices[dev_name].ip).send_dmx(base, payload)
             return {"status": "sent"}
 
         @self.app.post("/devices/{name}/effect")
@@ -198,7 +202,8 @@ class RestAPI:
             else:
                 raise HTTPException(status_code=400, detail="Unknown effect")
             payload = EffectEngine.to_bytes(frame)
-            ArtNetClient(self.devices[name].ip).send_dmx(0, payload)
+            base = self.devices[name].universe
+            ArtNetClient(self.devices[name].ip).send_dmx(base, payload)
             return {"status": "sent"}
 
         @self.app.post("/triggers/{event}")

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -19,3 +19,4 @@ def test_load_config(tmp_path):
     assert first.ip == "192.168.1.50"
     assert first.pixel_count == 150
     assert first.group == "stage_left"
+    assert first.universe == 0


### PR DESCRIPTION
## Summary
- support a per-device Art-Net universe
- propagate universe to REST API endpoints and default config
- test for universe in config loader

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687e99746f548332bdcd9c27c8196511