### PR TITLE
Add universe selection to web UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,15 @@ is available at `/panel` and the following API endpoints are exposed:
 * `POST /groups/{name}/command` – send a command to all devices in a group.
 * `POST /devices/{name}/effect` – run a built-in light effect on a device.
 * `POST /groups/{name}/effect` – run an effect on all devices in a group.
+* `POST /devices/{name}/color` – set a device to a solid color.
+* `POST /groups/{name}/color` – set a group of devices to a color.
 * `GET /favorites` – list stored colours.
 * `POST /favorites` – add a favourite colour.
 * `DELETE /favorites/{name}` – remove a favourite colour.
 * `POST /triggers/{event}` – trigger a named event hook.
+
+Color and effect endpoints accept an optional `universe` query parameter
+which is added to each device's base universe when sending data.
 
 Use any HTTP client or the web panel to manage your lighting setup.
 

--- a/src/rest_api.py
+++ b/src/rest_api.py
@@ -169,28 +169,30 @@ class RestAPI:
             return {"status": "sent"}
 
         @self.app.post("/devices/{name}/color")
-        def set_device_color(name: str, color: ColorPayload) -> Dict[str, str]:
+        def set_device_color(name: str, color: ColorPayload, universe: int = 0) -> Dict[str, str]:
             if name not in self.devices:
                 raise HTTPException(status_code=404, detail="Device not found")
             device = self.devices[name]
             frame = [Color(color.r, color.g, color.b) for _ in range(device.pixel_count)]
             payload = EffectEngine.to_bytes(frame)
-            ArtNetClient(device.ip).send_dmx(device.universe, payload)
+            base = device.universe
+            ArtNetClient(device.ip).send_dmx(base + universe, payload)
             return {"status": "sent"}
 
         @self.app.post("/groups/{name}/color")
-        def set_group_color(name: str, color: ColorPayload) -> Dict[str, str]:
+        def set_group_color(name: str, color: ColorPayload, universe: int = 0) -> Dict[str, str]:
             if name not in self.groups:
                 raise HTTPException(status_code=404, detail="Group not found")
             for dev_name in self.groups[name]:
                 device = self.devices[dev_name]
                 frame = [Color(color.r, color.g, color.b) for _ in range(device.pixel_count)]
                 payload = EffectEngine.to_bytes(frame)
-                ArtNetClient(device.ip).send_dmx(device.universe, payload)
+                base = device.universe
+                ArtNetClient(device.ip).send_dmx(base + universe, payload)
             return {"status": "sent"}
 
         @self.app.post("/groups/{name}/effect")
-        def run_group_effect(name: str, effect: str, step: int = 0) -> Dict[str, str]:
+        def run_group_effect(name: str, effect: str, step: int = 0, universe: int = 0) -> Dict[str, str]:
             if name not in self.groups:
                 raise HTTPException(status_code=404, detail="Group not found")
             for dev_name in self.groups[name]:
@@ -206,11 +208,11 @@ class RestAPI:
                     raise HTTPException(status_code=400, detail="Unknown effect")
                 payload = EffectEngine.to_bytes(frame)
                 base = self.devices[dev_name].universe
-                ArtNetClient(self.devices[dev_name].ip).send_dmx(base, payload)
+                ArtNetClient(self.devices[dev_name].ip).send_dmx(base + universe, payload)
             return {"status": "sent"}
 
         @self.app.post("/devices/{name}/effect")
-        def run_device_effect(name: str, effect: str, step: int = 0) -> Dict[str, str]:
+        def run_device_effect(name: str, effect: str, step: int = 0, universe: int = 0) -> Dict[str, str]:
             if name not in self.devices:
                 raise HTTPException(status_code=404, detail="Device not found")
             engine = self._get_engine(name)
@@ -232,7 +234,7 @@ class RestAPI:
                 raise HTTPException(status_code=400, detail="Unknown effect")
             payload = EffectEngine.to_bytes(frame)
             base = self.devices[name].universe
-            ArtNetClient(self.devices[name].ip).send_dmx(base, payload)
+            ArtNetClient(self.devices[name].ip).send_dmx(base + universe, payload)
             return {"status": "sent"}
 
         @self.app.post("/triggers/{event}")

--- a/src/static/panel.html
+++ b/src/static/panel.html
@@ -39,6 +39,7 @@
           <option value="group">Group</option>
         </select>
         <input type="color" id="color-picker" value="#ffffff">
+        <input id="color-universe" type="number" value="0" min="0" step="1" placeholder="Universe">
         <button type="submit">Send</button>
       </fieldset>
     </form>
@@ -56,6 +57,7 @@
           <option value="wave">Wave</option>
           <option value="flicker">Flicker</option>
         </select>
+        <input id="effect-universe" type="number" value="0" min="0" step="1" placeholder="Universe">
         <button type="submit">Run</button>
       </fieldset>
     </form>
@@ -97,8 +99,9 @@ document.getElementById('color-form').addEventListener('submit', async (e) => {
   const r = parseInt(hex.substring(0,2), 16);
   const g = parseInt(hex.substring(2,4), 16);
   const b = parseInt(hex.substring(4,6), 16);
+  const universe = parseInt(document.getElementById('color-universe').value || '0', 10);
   const payload = {r, g, b};
-  await postJson(`/${targetType}s/${name}/color`, payload);
+  await postJson(`/${targetType}s/${name}/color?universe=${universe}`, payload);
 });
 
 document.getElementById('effect-form').addEventListener('submit', async (e) => {
@@ -106,7 +109,8 @@ document.getElementById('effect-form').addEventListener('submit', async (e) => {
   const name = document.getElementById('effect-target').value;
   const targetType = document.getElementById('effect-type').value;
   const effect = document.getElementById('effect-name').value;
-  await fetch(`/${targetType}s/${name}/effect?effect=${effect}`, {method:'POST'});
+  const universe = parseInt(document.getElementById('effect-universe').value || '0', 10);
+  await fetch(`/${targetType}s/${name}/effect?effect=${effect}&universe=${universe}`, {method:'POST'});
 });
 </script>
 </body>


### PR DESCRIPTION
## Summary
- add `color` and `effect` REST endpoints to README
- document optional `universe` query parameter
- support universe offset for colour/effect API
- allow selecting universe in the web control panel

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687ea252c75083328475ad3a32497f8c