### PR TITLE
Update web panel for segment-based groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,12 +27,11 @@ devices:
   - name: "strip1"
     ip: "192.168.1.50"
     pixel_count: 150
-    group: "stage_left"
 ```
 
 Each device entry must define the Art-Net device IP address and the
-number of pixels it controls. Devices can optionally be assigned to a
-group.
+number of pixels it controls. Groups are created separately using
+segments from one or more devices.
 
 Load the configuration with:
 
@@ -87,7 +86,7 @@ is available at `/panel` and the following API endpoints are exposed:
 * `GET /devices` – list registered devices.
 * `POST /devices` – register a new device.
 * `GET /groups` – list groups and their members.
-* `POST /groups` – create a new group.
+* `POST /groups` – create a new group from device segments.
 * `POST /devices/{name}/command` – send a hex encoded DMX payload to a device.
 * `POST /groups/{name}/command` – send a command to all devices in a group.
 * `POST /devices/{name}/effect` – run a built-in light effect on a device.
@@ -100,5 +99,5 @@ is available at `/panel` and the following API endpoints are exposed:
 Use any HTTP client or the web panel to manage your lighting setup.
 
 The `/panel` route now serves a basic HTML interface which can register
-devices and send colour or effect commands. Open
+devices, create groups and send colour or effect commands. Open
 `http://localhost:8000/panel` in a browser to try it out.

--- a/config.example.yaml
+++ b/config.example.yaml
@@ -5,10 +5,18 @@ devices:
   - name: "strip1"
     ip: "192.168.1.50"
     pixel_count: 150
-    group: "stage_left"
     universe: 0
   - name: "strip2"
     ip: "192.168.1.51"
     pixel_count: 150
-    group: "stage_right"
     universe: 1
+
+# Groups can be created via the REST API. Example payload:
+# name: "stage"
+# segments:
+#   - device: "strip1"
+#     start: 0
+#     length: 75
+#   - device: "strip2"
+#     start: 0
+#     length: 75

--- a/src/config.py
+++ b/src/config.py
@@ -27,7 +27,6 @@ def load_config(path: str | Path) -> Config:
             name=item.get("name", f"device_{i}"),
             ip=item["ip"],
             pixel_count=item["pixel_count"],
-            group=item.get("group"),
             universe=item.get("universe", 0),
         )
         for i, item in enumerate(data.get("devices", []))

--- a/src/devices.py
+++ b/src/devices.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
+from typing import Dict, List
 
 
 @dataclass
@@ -22,3 +22,20 @@ class DeviceGroup:
 
     name: str
     devices: List[LEDDevice]
+
+
+@dataclass
+class LEDSegment:
+    """A segment of LEDs on a device."""
+
+    device: str
+    start: int
+    length: int
+
+
+@dataclass
+class LightGroup:
+    """Group of LED segments possibly across multiple devices."""
+
+    name: str
+    segments: List[LEDSegment]

--- a/src/devices.py
+++ b/src/devices.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Dict, List
+from typing import List
 
 
 @dataclass
@@ -12,16 +12,7 @@ class LEDDevice:
     name: str
     ip: str
     pixel_count: int
-    group: str | None = None
     universe: int = 0
-
-
-@dataclass
-class DeviceGroup:
-    """Logical group of multiple devices."""
-
-    name: str
-    devices: List[LEDDevice]
 
 
 @dataclass

--- a/src/rest_api.py
+++ b/src/rest_api.py
@@ -25,7 +25,6 @@ class DeviceModel(BaseModel):
     name: str
     ip: str
     pixel_count: int
-    group: Optional[str] = None
     universe: int = 0
 
 
@@ -118,7 +117,7 @@ class RestAPI:
         def register_device(device: DeviceModel) -> Dict[str, str]:
             if device.name in self.devices:
                 raise HTTPException(status_code=400, detail="Device already exists")
-            self.devices[device.name] = LEDDevice(**device.dict())
+            self.devices[device.name] = LEDDevice(**device.model_dump())
             return {"status": "registered"}
 
         @self.app.get("/groups")

--- a/src/static/panel.html
+++ b/src/static/panel.html
@@ -16,17 +16,30 @@
     <h2>Configuration</h2>
     <form id="device-form">
       <fieldset>
-        <legend>Add Device</legend>
-        <input name="name" placeholder="Name" required>
-        <input name="ip" placeholder="IP" required>
-        <input name="pixel_count" placeholder="Pixel count" type="number" required>
-        <input name="group" placeholder="Group">
-        <input name="universe" placeholder="Universe" type="number" value="0">
-        <button type="submit">Register</button>
-      </fieldset>
-    </form>
-    <div id="devices"></div>
-  </section>
+         <legend>Add Device</legend>
+         <input name="name" placeholder="Name" required>
+         <input name="ip" placeholder="IP" required>
+         <input name="pixel_count" placeholder="Pixel count" type="number" required>
+         <input name="universe" placeholder="Universe" type="number" value="0">
+         <button type="submit">Register</button>
+         </fieldset>
+      </form>
+      <div id="devices"></div>
+    </section>
+
+    <section>
+      <h2>Groups</h2>
+      <form id="group-form">
+        <fieldset>
+          <legend>Create Group</legend>
+          <input name="name" placeholder="Name" required>
+          <div id="segments"></div>
+          <button id="add-segment">Add Segment</button>
+          <button type="submit">Create</button>
+        </fieldset>
+      </form>
+      <div id="groups"></div>
+    </section>
 
   <section>
     <h2>Control</h2>
@@ -70,6 +83,16 @@ async function fetchDevices(){
 }
 fetchDevices();
 
+async function fetchGroups(){
+  const resp = await fetch('/groups');
+  const data = await resp.json();
+  const groups = Object.entries(data).map(([name, segs]) =>
+    name + ': ' + segs.map(s => `${s.device}[${s.start}-${s.start + s.length - 1}]`).join(', ')
+  );
+  document.getElementById('groups').innerText = groups.join('; ');
+}
+fetchGroups();
+
 async function postJson(url, payload){
   await fetch(url, {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload)});
 }
@@ -81,12 +104,42 @@ document.getElementById('device-form').addEventListener('submit', async (e) => {
     name: f.name.value,
     ip: f.ip.value,
     pixel_count: parseInt(f.pixel_count.value, 10),
-    group: f.group.value || null,
     universe: parseInt(f.universe.value || '0', 10)
   };
   await postJson('/devices', payload);
   f.reset();
   fetchDevices();
+});
+
+function addSegmentRow(){
+  const div = document.createElement('div');
+  div.className = 'segment';
+  div.innerHTML = '<input class="seg-device" placeholder="Device" required> ' +
+    '<input class="seg-start" placeholder="Start" type="number" value="0"> ' +
+    '<input class="seg-length" placeholder="Length" type="number" value="1">';
+  document.getElementById('segments').appendChild(div);
+}
+
+document.getElementById('add-segment').addEventListener('click', (e) => {
+  e.preventDefault();
+  addSegmentRow();
+});
+
+addSegmentRow();
+
+document.getElementById('group-form').addEventListener('submit', async (e) => {
+  e.preventDefault();
+  const segments = Array.from(document.querySelectorAll('#segments .segment')).map(div => ({
+    device: div.querySelector('.seg-device').value,
+    start: parseInt(div.querySelector('.seg-start').value, 10),
+    length: parseInt(div.querySelector('.seg-length').value, 10)
+  }));
+  const payload = {name: e.target.name.value, segments};
+  await postJson('/groups', payload);
+  e.target.reset();
+  document.getElementById('segments').innerHTML = '';
+  addSegmentRow();
+  fetchGroups();
 });
 
 document.getElementById('color-form').addEventListener('submit', async (e) => {

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -21,7 +21,13 @@ def test_register_device(client):
 
 def test_create_group(client):
     client.post("/devices", json={"name": "dev1", "ip": "1.2.3.4", "pixel_count": 10})
-    resp = client.post("/groups", json={"name": "g1", "devices": ["dev1"]})
+    resp = client.post(
+        "/groups",
+        json={
+            "name": "g1",
+            "segments": [{"device": "dev1", "start": 0, "length": 5}],
+        },
+    )
     assert resp.status_code == 200
     assert resp.json() == {"status": "group created"}
 

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -45,3 +45,55 @@ def test_run_effect(monkeypatch, client):
     assert resp.status_code == 200
     assert resp.json() == {"status": "sent"}
     assert calls
+
+
+def test_group_color(monkeypatch, client):
+    calls = []
+
+    def dummy_send(self, universe, data):
+        calls.append((self.target_ip, universe, data))
+
+    monkeypatch.setattr("src.network.ArtNetClient.send_dmx", dummy_send)
+
+    client.post("/devices", json={"name": "dev1", "ip": "1.2.3.4", "pixel_count": 5})
+    client.post("/devices", json={"name": "dev2", "ip": "1.2.3.5", "pixel_count": 5})
+    client.post(
+        "/groups",
+        json={
+            "name": "g1",
+            "segments": [
+                {"device": "dev1", "start": 0, "length": 5},
+                {"device": "dev2", "start": 0, "length": 5},
+            ],
+        },
+    )
+    resp = client.post("/groups/g1/color", json={"r": 10, "g": 20, "b": 30})
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "sent"}
+    assert len(calls) == 2
+
+
+def test_group_effect(monkeypatch, client):
+    calls = []
+
+    def dummy_send(self, universe, data):
+        calls.append((self.target_ip, universe, data))
+
+    monkeypatch.setattr("src.network.ArtNetClient.send_dmx", dummy_send)
+
+    client.post("/devices", json={"name": "dev1", "ip": "1.2.3.4", "pixel_count": 5})
+    client.post("/devices", json={"name": "dev2", "ip": "1.2.3.5", "pixel_count": 5})
+    client.post(
+        "/groups",
+        json={
+            "name": "g1",
+            "segments": [
+                {"device": "dev1", "start": 0, "length": 5},
+                {"device": "dev2", "start": 0, "length": 5},
+            ],
+        },
+    )
+    resp = client.post("/groups/g1/effect", params={"effect": "wave", "step": 0})
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "sent"}
+    assert len(calls) == 2

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,5 +18,5 @@ def test_load_config(tmp_path):
     assert first.name == "strip1"
     assert first.ip == "192.168.1.50"
     assert first.pixel_count == 150
-    assert first.group == "stage_left"
+    assert first.group is None
     assert first.universe == 0

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -18,5 +18,4 @@ def test_load_config(tmp_path):
     assert first.name == "strip1"
     assert first.ip == "192.168.1.50"
     assert first.pixel_count == 150
-    assert first.group is None
     assert first.universe == 0


### PR DESCRIPTION
## Summary
- remove group field from device form in web panel
- add interface for creating groups from segments
- display existing groups in the panel
- document new group model
- update config example and tests for groups

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_687ea3e8f2108332b8754c149491ca5a