### PR TITLE
Add proper ArtNet packet format

### DIFF
--- a/config.example.yaml
+++ b/config.example.yaml
@@ -6,6 +6,7 @@ devices:
     ip: "192.168.1.50"
     pixel_count: 150
     universe: 0
+    group: "stage_left"
   - name: "strip2"
     ip: "192.168.1.51"
     pixel_count: 150

--- a/src/config.py
+++ b/src/config.py
@@ -28,6 +28,7 @@ def load_config(path: str | Path) -> Config:
             ip=item["ip"],
             pixel_count=item["pixel_count"],
             universe=item.get("universe", 0),
+            group=item.get("group"),
         )
         for i, item in enumerate(data.get("devices", []))
     ]

--- a/src/devices.py
+++ b/src/devices.py
@@ -13,6 +13,7 @@ class LEDDevice:
     ip: str
     pixel_count: int
     universe: int = 0
+    group: str | None = None
 
 
 @dataclass

--- a/src/network.py
+++ b/src/network.py
@@ -13,18 +13,33 @@ class ArtNetClient:
     port: int = 6454  # standard Art-Net port
 
     def send_dmx(self, universe: int, data: bytes) -> None:
-        """Send a DMX payload to the configured Art-Net device.
+        """Send a DMX payload to the configured Art-Net device."""
 
-        This is a minimal implementation and does not build a full Art-Net
-        packet. Only a basic UDP payload is sent as a placeholder.
-        """
         payload = self._build_packet(universe, data)
         with socket.socket(socket.AF_INET, socket.SOCK_DGRAM) as sock:
             sock.sendto(payload, (self.target_ip, self.port))
 
     def _build_packet(self, universe: int, data: bytes) -> bytes:
-        """Return a minimal Art-Net packet for the given universe."""
-        # Proper Art-Net packet structure should be implemented here.
-        # For now this is just a stub sending raw data.
-        header = b"Art-Net\x00" + universe.to_bytes(2, "big")
-        return header + data
+        """Return a full Art-Net DMX packet for the given universe."""
+
+        if len(data) > 512:
+            raise ValueError("DMX payloads may not exceed 512 bytes")
+
+        # ID and OpCode for ArtDMX
+        packet = bytearray(b"Art-Net\x00")
+        packet.extend((0x00, 0x50))  # OpCode = ArtDMX (little endian)
+
+        # Protocol version 14 (0x000e) big endian
+        packet.extend((0x00, 0x0E))
+
+        # Sequence and physical
+        packet.extend((0x00, 0x00))
+
+        # Universe (little endian)
+        packet.extend(universe.to_bytes(2, "little"))
+
+        # Length of DMX data (big endian)
+        packet.extend(len(data).to_bytes(2, "big"))
+
+        packet.extend(data)
+        return bytes(packet)

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -6,6 +6,14 @@ def test_build_packet():
     data = b"\x01\x02\x03"
     packet = client._build_packet(1, data)
     assert packet.startswith(b"Art-Net\x00")
-    # Universe is big endian two bytes
-    assert packet[8:10] == b"\x00\x01"
-    assert packet[10:] == data
+    # OpCode should be ArtDMX (0x5000) little endian
+    assert packet[8:10] == b"\x00\x50"
+    # Protocol version 14
+    assert packet[10:12] == b"\x00\x0e"
+    # Sequence and physical
+    assert packet[12:14] == b"\x00\x00"
+    # Universe little endian
+    assert packet[14:16] == b"\x01\x00"
+    # Payload length big endian
+    assert packet[16:18] == b"\x00\x03"
+    assert packet[18:] == data


### PR DESCRIPTION
## Summary
- extend config example with a group entry
- support `group` for devices in `LEDDevice` and `load_config`
- implement full Art-Net DMX packet building
- update network packet tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687eb5d6be4c8332bd80d8c7f8ebeb7e