### PR TITLE
Add systemd install script for rpi Art-Net service

### DIFF
--- a/firmware/rpi_artnet_service/README.md
+++ b/firmware/rpi_artnet_service/README.md
@@ -18,3 +18,14 @@ clock to SCLK (GPIO11, physical pin 23).
 
 Install the appropriate CircuitPython library for your LED type before running
 (e.g. `pip install adafruit-circuitpython-neopixel`).
+
+## Systemd Installation
+
+Use the provided script to install the service so it starts on boot:
+
+```sh
+./install_service.sh
+```
+
+The script prompts for the target directory, Linux user, LED type and pin configuration,
+then creates a virtual environment and systemd unit. The service is enabled and started immediately.

--- a/firmware/rpi_artnet_service/install_service.sh
+++ b/firmware/rpi_artnet_service/install_service.sh
@@ -1,0 +1,66 @@
+#!/usr/bin/env bash
+set -e
+
+# Script to install the rpi_artnet_service as a systemd service.
+# Prompts the user for configuration, sets up a virtual environment,
+# and installs a systemd unit to run on boot.
+
+read -rp "Installation directory [/opt/rpi_artnet_service]: " INSTALL_DIR
+INSTALL_DIR=${INSTALL_DIR:-/opt/rpi_artnet_service}
+read -rp "Service user [pi]: " SERVICE_USER
+SERVICE_USER=${SERVICE_USER:-pi}
+read -rp "Service name [rpi_artnet]: " SERVICE_NAME
+SERVICE_NAME=${SERVICE_NAME:-rpi_artnet}
+
+LED_TYPE=""
+while [[ "$LED_TYPE" != "neopixel" && "$LED_TYPE" != "dotstar" ]]; do
+  read -rp "LED type (neopixel/dotstar): " LED_TYPE
+ done
+read -rp "Number of pixels: " NUM_PIXELS
+read -rp "Brightness [1.0]: " BRIGHTNESS
+BRIGHTNESS=${BRIGHTNESS:-1.0}
+
+if [[ "$LED_TYPE" == "neopixel" ]]; then
+  read -rp "Data pin [D18]: " PIN
+  PIN=${PIN:-D18}
+  LED_ARGS="--led-type neopixel --num-pixels ${NUM_PIXELS} --pin ${PIN} --brightness ${BRIGHTNESS}"
+  PYTHON_REQ="adafruit-circuitpython-neopixel"
+else
+  read -rp "Data pin [MOSI]: " DATA_PIN
+  DATA_PIN=${DATA_PIN:-MOSI}
+  read -rp "Clock pin [SCLK]: " CLOCK_PIN
+  CLOCK_PIN=${CLOCK_PIN:-SCLK}
+  LED_ARGS="--led-type dotstar --num-pixels ${NUM_PIXELS} --data-pin ${DATA_PIN} --clock-pin ${CLOCK_PIN} --brightness ${BRIGHTNESS}"
+  PYTHON_REQ="adafruit-circuitpython-dotstar"
+fi
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+
+sudo mkdir -p "${INSTALL_DIR}"
+sudo cp "${SCRIPT_DIR}/artnet_service.py" "${INSTALL_DIR}/"
+python3 -m venv "${INSTALL_DIR}/venv"
+"${INSTALL_DIR}/venv/bin/pip" install --upgrade pip
+"${INSTALL_DIR}/venv/bin/pip" install "${PYTHON_REQ}"
+
+SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
+sudo tee "${SERVICE_FILE}" > /dev/null <<SERVICE
+[Unit]
+Description=Raspberry Pi Art-Net LED Service
+After=network.target
+
+[Service]
+Type=simple
+User=${SERVICE_USER}
+WorkingDirectory=${INSTALL_DIR}
+ExecStart=${INSTALL_DIR}/venv/bin/python ${INSTALL_DIR}/artnet_service.py ${LED_ARGS}
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+SERVICE
+
+sudo systemctl daemon-reload
+sudo systemctl enable "${SERVICE_NAME}.service"
+sudo systemctl start "${SERVICE_NAME}.service"
+
+echo "Service ${SERVICE_NAME}.service installed and started."


### PR DESCRIPTION
## Summary
- add interactive `install_service.sh` to deploy `rpi_artnet_service` with systemd
- document systemd installation process for Raspberry Pi Art-Net LED service

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b228e94ee48328837c837570d47fad