### PR TITLE
Ensure rpi artnet service installs RPi.GPIO

### DIFF
--- a/firmware/rpi_artnet_service/README.md
+++ b/firmware/rpi_artnet_service/README.md
@@ -16,8 +16,12 @@ NeoPixel strips should be connected to GPIO18 (`D18`, physical pin 12). DotStar
 strips use the SPI0 interface: wire data to MOSI (GPIO10, physical pin 19) and
 clock to SCLK (GPIO11, physical pin 23).
 
-Install the appropriate CircuitPython library for your LED type before running
-(e.g. `pip install adafruit-circuitpython-neopixel`).
+Install the appropriate CircuitPython library for your LED type and the `RPi.GPIO`
+dependency before running. NeoPixel strips also require the `rpi_ws281x` library
+and must run with root privileges to access `/dev/mem`. For example, `pip install
+adafruit-circuitpython-neopixel RPi.GPIO rpi_ws281x`. The `install_service.sh`
+script installs these dependencies automatically and forces the systemd service
+to run as root when NeoPixel is selected.
 
 ## Systemd Installation
 

--- a/firmware/rpi_artnet_service/install_service.sh
+++ b/firmware/rpi_artnet_service/install_service.sh
@@ -24,14 +24,18 @@ if [[ "$LED_TYPE" == "neopixel" ]]; then
   read -rp "Data pin [D18]: " PIN
   PIN=${PIN:-D18}
   LED_ARGS="--led-type neopixel --num-pixels ${NUM_PIXELS} --pin ${PIN} --brightness ${BRIGHTNESS}"
-  PYTHON_REQ="adafruit-circuitpython-neopixel"
+  PYTHON_REQ=(adafruit-circuitpython-neopixel rpi_ws281x)
+  if [[ "$SERVICE_USER" != "root" ]]; then
+    echo "NeoPixel requires root privileges. Forcing service user to root."
+    SERVICE_USER=root
+  fi
 else
   read -rp "Data pin [MOSI]: " DATA_PIN
   DATA_PIN=${DATA_PIN:-MOSI}
   read -rp "Clock pin [SCLK]: " CLOCK_PIN
   CLOCK_PIN=${CLOCK_PIN:-SCLK}
   LED_ARGS="--led-type dotstar --num-pixels ${NUM_PIXELS} --data-pin ${DATA_PIN} --clock-pin ${CLOCK_PIN} --brightness ${BRIGHTNESS}"
-  PYTHON_REQ="adafruit-circuitpython-dotstar"
+  PYTHON_REQ=(adafruit-circuitpython-dotstar)
 fi
 
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
@@ -40,7 +44,7 @@ sudo mkdir -p "${INSTALL_DIR}"
 sudo cp "${SCRIPT_DIR}/artnet_service.py" "${INSTALL_DIR}/"
 python3 -m venv "${INSTALL_DIR}/venv"
 "${INSTALL_DIR}/venv/bin/pip" install --upgrade pip
-"${INSTALL_DIR}/venv/bin/pip" install "${PYTHON_REQ}"
+"${INSTALL_DIR}/venv/bin/pip" install RPi.GPIO "${PYTHON_REQ[@]}"
 
 SERVICE_FILE="/etc/systemd/system/${SERVICE_NAME}.service"
 sudo tee "${SERVICE_FILE}" > /dev/null <<SERVICE


### PR DESCRIPTION
## Summary
- fix rpi_artnet_service installer to install RPi.GPIO alongside LED driver packages
- document that the installer now installs RPi.GPIO dependency automatically
- force systemd service to run as root when NeoPixel is selected to satisfy hardware access requirements

## Testing
- `pytest`
- `shellcheck firmware/rpi_artnet_service/install_service.sh`


------
https://chatgpt.com/codex/tasks/task_e_68b4687b894883328104bf3cac5c51d6